### PR TITLE
One click

### DIFF
--- a/app/models/spree/adyen_common.rb
+++ b/app/models/spree/adyen_common.rb
@@ -191,47 +191,44 @@ module Spree
         end
 
         def decide_and_authorise(reference, amount, shopper, source, card, options)
-          binding.pry
           recurring_detail_reference = source.gateway_customer_profile_id
           card_cvc = source.verification_value
 
           if card_cvc.blank? && require_one_click_payment?(source, shopper)
-            binding.pry
+
             raise Core::GatewayError.new("You need to enter the card verificationv value")
           end
 
-          binding.pry
 
           if require_one_click_payment?(source, shopper) && recurring_detail_reference.present?
-            binding.pry
+
             provider.authorise_one_click_payment reference, amount, shopper, card_cvc, recurring_detail_reference
           elsif source.gateway_customer_profile_id.present?
-            binding.pry
+
             provider.authorise_recurring_payment reference, amount, shopper, source.gateway_customer_profile_id, nil, options
           else
-            binding.pry
+
             provider.authorise_payment reference, amount, shopper, card, options
           end
         end
 
         def create_profile_on_card(payment, card)
-          binding.pry
           unless payment.source.gateway_customer_profile_id.present?
             shopper = { :reference => payment.document_number,
                         :email => payment.order.email,
                         :ip => payment.order.last_ip_address,
                         :statement => "Order # #{payment.order.number}" }
 
-            binding.pry
+
 
             amount = build_amount_on_profile_creation payment
             options = build_authorise_details payment
 
-            binding.pry
+
 
             response = provider.authorise_payment payment.order.number, amount, shopper, card, options
 
-            binding.pry
+
 
             if response.success?
               fetch_and_update_contract payment.source, shopper[:reference]
@@ -256,13 +253,11 @@ module Spree
           list = provider.list_recurring_details(document_number)
 
 
-          binding.pry
 
           unless list.details.present?
             raise RecurringDetailsNotFoundError
           end
 
-          binding.pry
 
           source.update_columns(
             month: list.details.last[:card][:expiry_date].month,

--- a/app/models/spree/adyen_common.rb
+++ b/app/models/spree/adyen_common.rb
@@ -191,33 +191,47 @@ module Spree
         end
 
         def decide_and_authorise(reference, amount, shopper, source, card, options)
+          binding.pry
           recurring_detail_reference = source.gateway_customer_profile_id
           card_cvc = source.verification_value
 
           if card_cvc.blank? && require_one_click_payment?(source, shopper)
+            binding.pry
             raise Core::GatewayError.new("You need to enter the card verificationv value")
           end
 
+          binding.pry
+
           if require_one_click_payment?(source, shopper) && recurring_detail_reference.present?
+            binding.pry
             provider.authorise_one_click_payment reference, amount, shopper, card_cvc, recurring_detail_reference
           elsif source.gateway_customer_profile_id.present?
+            binding.pry
             provider.authorise_recurring_payment reference, amount, shopper, source.gateway_customer_profile_id, nil, options
           else
+            binding.pry
             provider.authorise_payment reference, amount, shopper, card, options
           end
         end
 
         def create_profile_on_card(payment, card)
+          binding.pry
           unless payment.source.gateway_customer_profile_id.present?
             shopper = { :reference => payment.document_number,
                         :email => payment.order.email,
                         :ip => payment.order.last_ip_address,
                         :statement => "Order # #{payment.order.number}" }
 
+            binding.pry
+
             amount = build_amount_on_profile_creation payment
             options = build_authorise_details payment
 
+            binding.pry
+
             response = provider.authorise_payment payment.order.number, amount, shopper, card, options
+
+            binding.pry
 
             if response.success?
               fetch_and_update_contract payment.source, shopper[:reference]
@@ -241,9 +255,14 @@ module Spree
           # need to reach the api again to grab the token
           list = provider.list_recurring_details(document_number)
 
+
+          binding.pry
+
           unless list.details.present?
             raise RecurringDetailsNotFoundError
           end
+
+          binding.pry
 
           source.update_columns(
             month: list.details.last[:card][:expiry_date].month,

--- a/app/models/spree/adyen_common.rb
+++ b/app/models/spree/adyen_common.rb
@@ -198,18 +198,14 @@ module Spree
           card_cvc = source.verification_value
 
           if card_cvc.blank? && require_one_click_payment?(source, shopper)
-
             raise Core::GatewayError.new("You need to enter the card verificationv value")
           end
 
           if require_one_click_payment?(source, shopper) && recurring_detail_reference.present?
-
             provider.authorise_one_click_payment reference, amount, shopper, card_cvc, recurring_detail_reference
           elsif source.gateway_customer_profile_id.present?
-
             provider.authorise_recurring_payment reference, amount, shopper, source.gateway_customer_profile_id, nil, options
           else
-
             provider.authorise_payment reference, amount, shopper, card, options
           end
         end

--- a/app/models/spree/adyen_common.rb
+++ b/app/models/spree/adyen_common.rb
@@ -202,7 +202,6 @@ module Spree
             raise Core::GatewayError.new("You need to enter the card verificationv value")
           end
 
-
           if require_one_click_payment?(source, shopper) && recurring_detail_reference.present?
 
             provider.authorise_one_click_payment reference, amount, shopper, card_cvc, recurring_detail_reference
@@ -222,16 +221,10 @@ module Spree
                         :ip => payment.order.last_ip_address,
                         :statement => "Order # #{payment.order.number}" }
 
-
-
             amount = build_amount_on_profile_creation payment
             options = build_authorise_details payment
 
-
-
             response = provider.authorise_payment payment.order.number, amount, shopper, card, options
-
-
 
             if response.success?
               last_digits = response.additional_data["cardSummary"]

--- a/app/models/spree/adyen_common.rb
+++ b/app/models/spree/adyen_common.rb
@@ -3,6 +3,7 @@ module Spree
     extend ActiveSupport::Concern
 
     class RecurringDetailsNotFoundError < StandardError; end
+    class MissingCardSummaryError < StandardError; end
 
     included do
       preference :api_username, :string
@@ -148,6 +149,14 @@ module Spree
           response = authorize_on_card 0, source, options, card, { recurring: true }
 
           if response.success?
+            last_digits = response.additional_data["cardSummary"]
+            if last_digits.blank? && payment_profiles_supported?
+              note = "Payment was authorized but could not fetch last digits.
+                      Please request last digits to be sent back to support payment profiles"
+              raise Adyen::MissingCardSummaryError, note
+            end
+
+            source.last_digits = last_digits
             fetch_and_update_contract source, options[:customer_id]
           else
             response.error
@@ -214,6 +223,14 @@ module Spree
             response = provider.authorise_payment payment.order.number, amount, shopper, card, options
 
             if response.success?
+              last_digits = response.additional_data["cardSummary"]
+              if last_digits.blank? && payment_profiles_supported?
+                note = "Payment was authorized but could not fetch last digits.
+                        Please request last digits to be sent back to support payment profiles"
+                raise Adyen::MissingCardSummaryError, note
+              end
+
+              payment.source.last_digits = last_digits
               fetch_and_update_contract payment.source, shopper[:reference]
 
               payment.pend!
@@ -231,21 +248,19 @@ module Spree
         end
 
         def fetch_and_update_contract(source, document_number)
-          # Adyen doesn't give us the recurring reference (token) so we
-          # need to reach the api again to grab the token
           list = provider.list_recurring_details(document_number)
 
-          unless list.details.present?
-            raise RecurringDetailsNotFoundError
-          end
+          raise RecurringDetailsNotFoundError unless list.details.present?
+          card = list.details.find { |c| c[:card][:number] == source.last_digits }
+          raise RecurringDetailsNotFoundError unless card.present?
 
           source.update_columns(
-            month: list.details.last[:card][:expiry_date].month,
-            year: list.details.last[:card][:expiry_date].year,
-            name: list.details.last[:card][:holder_name],
-            cc_type: list.details.last[:variant],
-            last_digits: list.details.last[:card][:number],
-            gateway_customer_profile_id: list.details.last[:recurring_detail_reference],
+            month: card[:card][:expiry_date].month,
+            year: card[:card][:expiry_date].year,
+            name: card[:card][:holder_name],
+            cc_type: card[:variant],
+            last_digits: card[:card][:number],
+            gateway_customer_profile_id: card[:recurring_detail_reference],
             document_number: document_number
           )
         end

--- a/app/models/spree/gateway/adyen_payment_encrypted.rb
+++ b/app/models/spree/gateway/adyen_payment_encrypted.rb
@@ -16,10 +16,6 @@ module Spree
       true
     end
 
-    def require_one_click_payment?(source, shopper)
-      true
-    end
-
     def actions
       %w(capture void)
     end

--- a/app/models/spree/gateway/adyen_payment_encrypted_one_click.rb
+++ b/app/models/spree/gateway/adyen_payment_encrypted_one_click.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Gateway::AdyenPaymentEncrypted < Gateway
+  class Gateway::AdyenPaymentEncryptedOneClick < Gateway
     include AdyenCommon
 
     preference :public_key, :string

--- a/app/models/spree/gateway/adyen_payment_encrypted_recurring.rb
+++ b/app/models/spree/gateway/adyen_payment_encrypted_recurring.rb
@@ -1,5 +1,5 @@
 module Spree
-  class Gateway::AdyenPaymentEncrypted < Gateway
+  class Gateway::AdyenPaymentEncryptedRecurring < Gateway
     include AdyenCommon
 
     preference :public_key, :string
@@ -13,10 +13,6 @@ module Spree
     end
 
     def payment_profiles_supported?
-      true
-    end
-
-    def require_one_click_payment?(source, shopper)
       true
     end
 

--- a/lib/spree/adyen/engine.rb
+++ b/lib/spree/adyen/engine.rb
@@ -9,6 +9,8 @@ module Spree
         app.config.spree.payment_methods << Gateway::AdyenPayment
         app.config.spree.payment_methods << Gateway::AdyenHPP
         app.config.spree.payment_methods << Gateway::AdyenPaymentEncrypted
+        app.config.spree.payment_methods << Gateway::AdyenPaymentEncryptedOneClick
+        app.config.spree.payment_methods << Gateway::AdyenPaymentEncryptedRecurring
       end
 
       initializer "spree-adyen.assets.precompile", :group => :all do |app|


### PR DESCRIPTION
This commit adds two new classes: AdyenPaymentEncryptedOneClick and AdyenPaymentEncryptedRecurring. The first one has the "require_one_click_payment?" method, which require cvc to be passed on recurring purchases. The other class is a copy of the encrypted old one. I just replicated with a different name.
