### PR TITLE
save response code in failed adyen transactions for new cards

### DIFF
--- a/app/models/spree/adyen_common.rb
+++ b/app/models/spree/adyen_common.rb
@@ -271,6 +271,7 @@ module Spree
 
             response = provider.authorise_payment payment.order.number, amount, shopper, card, options
             log_authorize_details(:create_profile_on_card, "#{payment.order.number}-#{payment.identifier}", amount, options, response)
+            payment.response_code = response.psp_reference if response && response.respond_to?(:psp_reference)
 
             if response.success?
               last_digits = response.additional_data["cardSummary"]
@@ -288,7 +289,6 @@ module Spree
               end
 
               #sets response_code to payment object when creating profiles
-              payment.response_code = response.psp_reference
               payment.pend!
 
             elsif response.respond_to?(:enrolled_3d?) && response.enrolled_3d?


### PR DESCRIPTION
Seta os response codes para situações de sucesso e de falhas. Não consegui testar pois os cartões de teste da adyen que geram problemas especificos falham na criação do cartão e não na venda, mas dessa forma vai setar para ambos os casos.